### PR TITLE
Drawers bugfix

### DIFF
--- a/layout/drawers.php
+++ b/layout/drawers.php
@@ -118,7 +118,11 @@ if ($PAGE->has_secondary_navigation()) {
     $tablistnav = $PAGE->has_tablist_secondary_navigation();
     $moremenu = new \core\navigation\output\more_menu($PAGE->secondarynav, 'nav-tabs', true, $tablistnav);
     $secondarynavigation = $moremenu->export_for_template($OUTPUT);
-    $overflowdata = $PAGE->secondarynav->get_overflow_menu_data();
+    try {
+        $overflowdata = $PAGE->secondarynav->get_overflow_menu_data();
+    } catch (\TypeError $e) {
+        $overflowdata = null;
+    }
     if (!is_null($overflowdata)) {
         $overflow = $overflowdata->export_for_template($OUTPUT);
     }


### PR DESCRIPTION
This PR attempts to fix a bug found in /layout/drawers.php specifically replicated by:

1. Accessing your Moodle site and going to the /backup/view.php page of a given course. I couldn't seem to replicate this as a siteadmin but rather just as a normal user with course editing/backup/restore permissions.
2. See the below fatal error output:

Error Exception - core\output\url_select::__construct(): Argument #1 ($urls) must be of type array, null given, called in [dirroot]/lib/classes/navigation/views/secondary.php on line 639 
Debug info: Error code: generalexceptionmessage 
Stack trace: line 110 of /lib/classes/output/url_select.php: TypeError thrown line 639 of /lib/classes/navigation/views/secondary.php: call to core\output\url_select->__construct() line 121 of /theme/boost_union/layout/drawers.php: call to core\navigation\views\secondary->get_overflow_menu_data() line 972 of /lib/classes/output/core_renderer.php: call to include() line 888 of /lib/classes/output/core_renderer.php: call to core\output\core_renderer->render_page_layout() line 824 of /theme/boost_union/classes/output/core_renderer.php: call to core\output\core_renderer->header() line ? of unknownfile: call to theme_boost_union\output\core_renderer->header() line 109 of /lib/classes/output/bootstrap_renderer.php: call to call_user_func_array() line 50 of /backup/view.php: call to core\output\bootstrap_renderer->__call()